### PR TITLE
Split single string of words into many strings.

### DIFF
--- a/doublets/test/doublets/solver_test.clj
+++ b/doublets/test/doublets/solver_test.clj
@@ -7,13 +7,13 @@
     (is (= ["head" "heal" "teal" "tell" "tall" "tail"]
            (doublets "head" "tail")))
 
-    (is (= ["door boor book look lock"]
+    (is (= ["door" "boor" "book" "look" "lock"]
            (doublets "door" "lock")))
 
-    (is (= ["bank bonk book look loon loan"]
+    (is (= ["bank" "bonk" "book" "look" "loon" "loan"]
            (doublets "bank" "loan")))
 
-    (is (= ["wheat cheat cheap creep breed bread"]
+    (is (= ["wheat" "cheat" "cheap" "creep" "breed" "bread"]
            (doublets "wheat" "bread"))))
 
   (testing "with no word links found"


### PR DESCRIPTION
Noticed that the doublet tests were expecting a single string with multiple words instead of multiple strings. This commit changes the assertions to expect multiple strings.
