### PR TITLE
Update solver_test.clj

### DIFF
--- a/doublets/README.md
+++ b/doublets/README.md
@@ -66,6 +66,8 @@ A sample dictionary has been included with a few words to get things going.  Aft
 
 Once you have your kata solution, you are welcome to submit a link to your repo to share here in this section with others.
 
+https://github.com/gensym/wonderland-clojure-katas/tree/doublets-solution/doublets
+
 If you haven't solved your kata yet - Don't Peek!
 
 ## License


### PR DESCRIPTION
Added missing step  ("creep" -> "creed" -> "breed") in the "wheat" -> "bread" doublet
