### PR TITLE
Changed fox-goose-corn test so that the assertion does not care about th...

### DIFF
--- a/fox-goose-bag-of-corn/test/fox_goose_bag_of_corn/puzzle_test.clj
+++ b/fox-goose-bag-of-corn/test/fox_goose_bag_of_corn/puzzle_test.clj
@@ -22,5 +22,5 @@
 
 (deftest test-river-crossing-plan
   (testing "the fox, goose, corn, and you all made it to the other side of the river"
-    (is (= (map set solution)
-           (map set (river-crossing-plan))))))
+    (is (= (map (partial map set) solution)
+           (map (partial map set) (river-crossing-plan))))))


### PR DESCRIPTION
...e order of parties within each position

Prior to this commit, the assertion ignored the order of positions (left bank, river, right bank), rather than ignoring the order of the parties within each position. I believe this commit changes the assertion to what was originally intended. 
