### PR TITLE
Correct spelling mistake

### DIFF
--- a/doublets/README.md
+++ b/doublets/README.md
@@ -56,7 +56,7 @@ bread
 
 ## Instructions
 
-- Clone of fork this repo
+- Clone or fork this repo
 - `cd doublets`
 - Run the tests with `lein test`
 - Make the tests pass!


### PR DESCRIPTION
For the want of an r, that rabbit scurried home.