### PR TITLE
Tiny 'fix' 

### DIFF
--- a/wonderland-number/test/wonderland_number/finder_test.clj
+++ b/wonderland-number/test/wonderland_number/finder_test.clj
@@ -10,7 +10,7 @@
 (deftest test-wonderland-number
   (testing "A wonderland number must have the following things true about it"
     (let [wondernum (wonderland-number)]
-      (is (= 6 (count (str (wonderland-number)))))
+      (is (= 6 (count (str wondernum))))
       (is (hasAllTheSameDigits? wondernum (* 2 wondernum)))
       (is (hasAllTheSameDigits? wondernum (* 3 wondernum)))
       (is (hasAllTheSameDigits? wondernum (* 4 wondernum)))


### PR DESCRIPTION
* for not needlessly re-calculating the `wonderland-number` in the tests