### PR TITLE
Add :main namespace to project.clj files

### DIFF
--- a/alphabet-cipher/project.clj
+++ b/alphabet-cipher/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main alphabet-cipher.coder)

--- a/card-game-war/project.clj
+++ b/card-game-war/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main card-game-war.game)

--- a/doublets/project.clj
+++ b/doublets/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main doublets.solver)

--- a/fox-goose-bag-of-corn/project.clj
+++ b/fox-goose-bag-of-corn/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main fox-goose-bag-of-corn.puzzle)

--- a/magic-square/project.clj
+++ b/magic-square/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main magic-square.puzzle)

--- a/tiny-maze/project.clj
+++ b/tiny-maze/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main tiny-maze.solver)

--- a/wonderland-number/project.clj
+++ b/wonderland-number/project.clj
@@ -3,4 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :main wonderland-number.finder)


### PR DESCRIPTION
I was having trouble getting CIDER up and running with the katas after having emacs set up as described in [clojure for the brave and true](http://www.braveclojure.com/basic-emacs/). With a little help I found out it was due to undefined main namespaces in the project files. As I find the REPL to be extremely useful I added the correct namespace to each file, so other people coming from the book might get it running more quickly.