### PR TITLE
Add another decipher test

### DIFF
--- a/alphabet-cipher/test/alphabet_cipher/coder_test.clj
+++ b/alphabet-cipher/test/alphabet_cipher/coder_test.clj
@@ -21,4 +21,6 @@
     (is (= "vigilance"
            (decipher "opkyfipmfmwcvqoklyhxywgeecpvhelzg" "thequickbrownfoxjumpsoveralazydog")))
     (is (= "scones"
-           (decipher "hcqxqqtqljmlzhwiivgbsapaiwcenmyu" "packmyboxwithfivedozenliquorjugs")))))
+           (decipher "hcqxqqtqljmlzhwiivgbsapaiwcenmyu" "packmyboxwithfivedozenliquorjugs")))
+    (is (= "abcabcx"
+           (decipher "hfnlphoontutufa" "hellofromrussia")))))


### PR DESCRIPTION
There is a case when a keyword partly repeats itself. For example, the keyword `"abcabcx"` contains two substring `"abc"` following by each other. I noticed that some solutions listed in [README.md](https://github.com/gigasquid/wonderland-clojure-katas/blob/master/alphabet-cipher/README.md) returns only `"abc"` in this case. So I've added another decipher test to make this kata stronger.