### PR TITLE
Use relative path for images in README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ These are a collection of Clojure
 [Lewis Carroll](http://en.wikipedia.org/wiki/Lewis_Carroll) and _Alice
 in Wonderland_.
 
-![Alice and the tiny door](/images/alicedoor.gif)
+![Alice and the tiny door](./images/alicedoor.gif)
 
 >“Curiouser and curiouser!” 
 >-- ― Lewis Carroll, Alice in Wonderland

--- a/alphabet-cipher/README.md
+++ b/alphabet-cipher/README.md
@@ -3,7 +3,7 @@
 Lewis Carroll published a cipher known as
 [The Alphabet Cipher](http://en.wikipedia.org/wiki/The_Alphabet_Cipher)
 
-![Letter](/images/fishfrogletter.gif)
+![Letter](../images/fishfrogletter.gif)
 
 This Alphabet Cipher involves alphabet substitution using a keyword.
 

--- a/card-game-war/README.md
+++ b/card-game-war/README.md
@@ -2,7 +2,7 @@
 
 This kata is a version of the classic card game [War](http://en.wikipedia.org/wiki/War_%28card_game%29).
 
-![Cards Painting](/images/cardspainting.gif)
+![Cards Painting](../images/cardspainting.gif)
 
 
 The rules of this card game are quite simple.

--- a/doublets/README.md
+++ b/doublets/README.md
@@ -3,7 +3,7 @@
 This Clojure Kata comes from _Alice in Wonderland_'s author, Lewis
 Carroll. He came up with this word puzzle that he named _Doublets_.
 
-![Mad Hatter](/images/madhatter.gif)
+![Mad Hatter](../images/madhatter.gif)
 
 The puzzle is to take two words of the same length and find a way of linking the
 first word to the second word by only changing one letter at a time.  At the end of the transformation,

--- a/fox-goose-bag-of-corn/README.md
+++ b/fox-goose-bag-of-corn/README.md
@@ -4,7 +4,7 @@ One of Lewis Carroll's favorite puzzles to ask children was the one
 about the _Fox, Goose, and Bag of Corn_.  It has to do with getting
 them all safely across a river.
 
-![alice swimming](/images/storytelling.gif)
+![alice swimming](../images/storytelling.gif)
 
 
 The rules for this puzzle are:

--- a/magic-square/README.md
+++ b/magic-square/README.md
@@ -4,7 +4,7 @@ This puzzle comes from Lewis Carroll.  The magic part is when the
 values on a square are arranged so that adding them up in any direction results in
 a constant sum.
 
-![caterpillar](/images/caterpillar.gif)
+![caterpillar](../images/caterpillar.gif)
 
 You have the following values:
 

--- a/tiny-maze/README.md
+++ b/tiny-maze/README.md
@@ -3,7 +3,7 @@
 Alice found herself very tiny and wandering around Wonderland.  Even
 the grass around her seemed like a maze.
 
-![alice tiny](/images/alicetiny.gif)
+![alice tiny](../images/alicetiny.gif)
 
 This is a tiny maze solver.
 

--- a/wonderland-number/README.md
+++ b/wonderland-number/README.md
@@ -3,7 +3,7 @@
 Wonderland is a strange place.  There is a wonderland number that is
 also quite strange.
 
-![White Rabbit](/images/whiterabbit.gif)
+![White Rabbit](../images/whiterabbit.gif)
 
 
 You must find a way to generate this wonderland number.


### PR DESCRIPTION
This commit changes the image tag in `README.md` files (both root project as well as sub-katas) so that the relative path is used to refer to the image directory. 
GitHub doesn't seem to care and outputs both variants correctly, however some other renderers installed on the local machine don't. This PR fixes this issue for Intellij IDEA with AsciiDoc plugin and eventually other viewers as well.