### PR TITLE
Migrate to Clojure CLI and Latest Version of Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.clj-kondo/
+.cpcache/
+.lsp/

--- a/README.md
+++ b/README.md
@@ -13,20 +13,16 @@ in Wonderland_.
 ## How to Do the Katas
 
 First, clone or fork this repo. Each of the katas are in their own
-directory and are self contained Clojure leiningen projects.  You `cd`
-into the project and run `clj -X:test` or `lein test` to show the failing tests, then
+directory and are self contained Clojure projects.  You `cd`
+into the project and run `clj -X:test` to show the failing tests, then
 complete the code to make the tests pass. Each project has the
 instructions in its own _README.md_ file.
-
-If you want to use Leiningen and don't have it installed yet.  Follow these [instructions](http://leiningen.org/)
-to get it. 
-
 
 For example, to get started on the _alphabet-cipher_ kata first.
 
 1. Clone or Fork this repo
 2. cd `alphabet-cipher`
-3. run `clj -X:test` or `lein test` 
+3. run `clj -X:test`
 4. Check out the alphabet cipher instructions in the _README.md_.
 5. Add the code in the source files to make the tests pass.
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,19 @@ in Wonderland_.
 
 First, clone or fork this repo. Each of the katas are in their own
 directory and are self contained Clojure leiningen projects.  You `cd`
-into the project and run `lein test` to show the failing tests, then
+into the project and run `clj -X:test` or `lein test` to show the failing tests, then
 complete the code to make the tests pass. Each project has the
 instructions in its own _README.md_ file.
 
-If you don't have Leiningen installed yet.  Follow these [instructions](http://leiningen.org/)
-to get it.
+If you want to use Leiningen and don't have it installed yet.  Follow these [instructions](http://leiningen.org/)
+to get it. 
+
 
 For example, to get started on the _alphabet-cipher_ kata first.
 
 1. Clone or Fork this repo
 2. cd `alphabet-cipher`
-3. run `lein test`
+3. run `clj -X:test` or `lein test` 
 4. Check out the alphabet cipher instructions in the _README.md_.
 5. Add the code in the source files to make the tests pass.
 

--- a/alphabet-cipher/README.md
+++ b/alphabet-cipher/README.md
@@ -72,7 +72,7 @@ To decode, the person would use the secret keyword and do the opposite.
 
 - Clone or fork this repo
 - `cd alphabet-cipher`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 ## Solutions

--- a/alphabet-cipher/deps.edn
+++ b/alphabet-cipher/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/alphabet-cipher/deps.edn
+++ b/alphabet-cipher/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/alphabet-cipher/project.clj
+++ b/alphabet-cipher/project.clj
@@ -1,7 +1,0 @@
-(defproject alphabet-cipher "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main alphabet-cipher.coder)

--- a/card-game-war/README.md
+++ b/card-game-war/README.md
@@ -23,7 +23,7 @@ If you are stuck, you might want to sneak a peak at this [sample scenario](sampl
 
 - Clone or fork this repo
 - `cd card-game-war`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - In this kata, you will be prompted to fill in your own tests.
 - Make the tests pass!
 

--- a/card-game-war/deps.edn
+++ b/card-game-war/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/card-game-war/deps.edn
+++ b/card-game-war/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/card-game-war/project.clj
+++ b/card-game-war/project.clj
@@ -1,7 +1,0 @@
-(defproject card-game-war "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main card-game-war.game)

--- a/doublets/README.md
+++ b/doublets/README.md
@@ -58,7 +58,7 @@ bread
 
 - Clone or fork this repo
 - `cd doublets`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 A sample dictionary has been included with a few words to get things going.  After you solve the kata, you might want to try a bigger dictionary to discover more exciting doublets.

--- a/doublets/deps.edn
+++ b/doublets/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/doublets/deps.edn
+++ b/doublets/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/doublets/project.clj
+++ b/doublets/project.clj
@@ -1,7 +1,0 @@
-(defproject doublets "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main doublets.solver)

--- a/fox-goose-bag-of-corn/README.md
+++ b/fox-goose-bag-of-corn/README.md
@@ -43,7 +43,7 @@ The goal is to have the plan in steps so that all make it safely to the other si
 
 - Clone or fork this repo
 - `cd fox-goose-bag-of-corn`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 ## Solutions

--- a/fox-goose-bag-of-corn/deps.edn
+++ b/fox-goose-bag-of-corn/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/fox-goose-bag-of-corn/deps.edn
+++ b/fox-goose-bag-of-corn/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/fox-goose-bag-of-corn/project.clj
+++ b/fox-goose-bag-of-corn/project.clj
@@ -1,7 +1,0 @@
-(defproject fox-goose-bag-of-corn "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main fox-goose-bag-of-corn.puzzle)

--- a/magic-square/README.md
+++ b/magic-square/README.md
@@ -31,7 +31,7 @@ You need to arrange them in a 3 x 3 matrix so that:
 
 - Clone or fork this repo
 - `cd magic-square`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 ## Solutions

--- a/magic-square/deps.edn
+++ b/magic-square/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/magic-square/deps.edn
+++ b/magic-square/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/magic-square/project.clj
+++ b/magic-square/project.clj
@@ -1,7 +1,0 @@
-(defproject magic-square "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main magic-square.puzzle)

--- a/tiny-maze/README.md
+++ b/tiny-maze/README.md
@@ -34,7 +34,7 @@ _:x_ in the start, the path, and the end of the maze, like this.
 
 - Clone or fork this repo
 - `cd tiny-maze`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 ## Solutions

--- a/tiny-maze/deps.edn
+++ b/tiny-maze/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/tiny-maze/deps.edn
+++ b/tiny-maze/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/tiny-maze/project.clj
+++ b/tiny-maze/project.clj
@@ -1,7 +1,0 @@
-(defproject tiny-maze "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main tiny-maze.solver)

--- a/wonderland-number/README.md
+++ b/wonderland-number/README.md
@@ -19,7 +19,7 @@ You must find a way to generate this wonderland number.
 
 - Clone or fork this repo
 - `cd wonderland-number`
-- Run the tests with `lein test`
+- Run the tests with `clj -X:test`
 - Make the tests pass!
 
 ## Solutions

--- a/wonderland-number/deps.edn
+++ b/wonderland-number/deps.edn
@@ -1,3 +1,9 @@
 {
+ :paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}
 }

--- a/wonderland-number/deps.edn
+++ b/wonderland-number/deps.edn
@@ -1,0 +1,3 @@
+{
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+}

--- a/wonderland-number/project.clj
+++ b/wonderland-number/project.clj
@@ -1,7 +1,0 @@
-(defproject wonderland-number "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :main wonderland-number.finder)


### PR DESCRIPTION
I've added the option to use the Clojure CLI tools and `deps.edn` to the top level README and included a `deps.edn` for each kata.